### PR TITLE
Add CNAME file and remove old deployment scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,11 +23,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject",
-    "predeploy": "npm run build",
-    "add-domain": "echo zothacks.com > public/CNAME",
-    "deploy": "npm run add-domain && npm run build --prefix-paths && gh-pages -d build",
-    "serve": "npx serve -s build"
+    "eject": "react-scripts eject"
   },
   "eslintConfig": {
     "extends": "react-app"
@@ -43,8 +39,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "devDependencies": {
-    "gh-pages": "^4.0.0"
   }
 }

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+zothacks.com


### PR DESCRIPTION
Currently, the custom domain needs to be reconfigured on each deploy. Instead of manually configuring, we can include a CNAME file for GitHub Pages to use the custom domain. We can also remove the old deployment scripts that have been replaced by the `deploy-gh-pages.yml` workflow.