### PR TITLE
Add workflow to build project on pull requests

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,0 +1,25 @@
+name: Attempt to build project for pull requests
+
+on:
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+          cache: "npm"
+          cache-dependency-path: "**/package-lock.json"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build React project
+        run: npm run build


### PR DESCRIPTION
To avoid workflow failures from ESLint errors during React build, run build script when submitting a pull request to the main branch.
Aside: we should set up a more refined ESLint configuration.