### PR TITLE
Add ZotHacks 2024 Colors

### DIFF
--- a/apps/site/src/lib/styles/_zothacks-theme.scss
+++ b/apps/site/src/lib/styles/_zothacks-theme.scss
@@ -1,19 +1,22 @@
 // Common variables for site theme consistency
 
 // colors
-$white: #fafaff; // Paper Background color
+$white: #ffffff;
+$black: #0b0a22;
+$lighter-black: #1a1840; // Other text color
+$red: #bd5a5a;
+$light-green: #dafff5;
+$light-blue: #01a7c5;
+$purple: #78638a;
+
 $beige: #faf4ea;
-$black: #21242d; // Text color
 $silver: #e6f2fc; // Line pattern color of paper
-$red: #ff3750;
 $pink: #ffa8c3;
 $orange: #ff5c00;
 $gold: #ffd600; // accent colors
 $yellow: #ffff00; // highlighter
 $sticky-yellow: #ffffa9;
 $green: #3df048;
-$light-blue: #81deeb;
 $blue: #3902fd;
-$purple: #6600b6;
 $navbar-red: #ff0000;
 $brown: #aa703c;


### PR DESCRIPTION
## Colors Added:

- white (#ffffff)
- black (#0b0a22)
- a lighter black (#1a1840)
- red (#bd5a5a)
- light-green (#dafff5)
- light-blue (#01a7c5)
- purple (#78638a)