### PR TITLE
Add gold tier to sponsor tiers in Sanity schema

### DIFF
--- a/apps/sanity/schemas/sponsors.ts
+++ b/apps/sanity/schemas/sponsors.ts
@@ -34,12 +34,16 @@ export default defineType({
 							options: {
 								list: [
 									{
-										title: "Bronze",
-										value: "bronze",
+										title: "Gold",
+										value: "gold",
 									},
 									{
 										title: "Silver",
 										value: "silver",
+									},
+									{
+										title: "Bronze",
+										value: "bronze",
 									},
 								],
 								layout: "radio",


### PR DESCRIPTION
- The existing tier options in the sponsors Sanity schema only includes silver and bronze, but with a sponsor buying a gold tier, this PR will add a gold option to the Sanity schema