### PR TITLE
Fix zod validation for getSponsors

### DIFF
--- a/apps/site/src/app/(home)/sections/Sponsors/getSponsors.ts
+++ b/apps/site/src/app/(home)/sections/Sponsors/getSponsors.ts
@@ -10,7 +10,11 @@ const Sponsors = SanityDocument.extend({
 			_key: z.string(),
 			name: z.string(),
 			url: z.string().url().optional(),
-			tier: z.union([z.literal("bronze"), z.literal("silver")]),
+			tier: z.union([
+				z.literal("bronze"),
+				z.literal("silver"),
+				z.literal("gold"),
+			]),
 			logo: SanityImageReference,
 		}),
 	),


### PR DESCRIPTION
- Since another sponsors tier was added (gold), the zod validation for the data fetched from Sanity will need to be updated.