### PR TITLE
Add decline acceptance button to hacker portal

### DIFF
--- a/apps/site/src/app/portal/DeclineAcceptanceBox.tsx
+++ b/apps/site/src/app/portal/DeclineAcceptanceBox.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import PrimaryButton from "@/components/PrimaryButton/PrimaryButton";
+
+import styles from "./PortalDashboard.module.scss";
+
+const confirmationMessage =
+	"Are you sure? This will void your application and you will no longer be considered for ZotHacks 2026.";
+
+export default function DeclineAcceptanceBox() {
+	return (
+		<form
+			method="post"
+			action="/api/user/decline-acceptance"
+			className={styles.declineForm}
+			onSubmit={(event) => {
+				if (!confirm(confirmationMessage)) {
+					event.preventDefault();
+				}
+			}}
+		>
+			<PrimaryButton type="submit" color="red" className={styles.declineButton}>
+				I am no longer able to attend ZotHacks 2026
+			</PrimaryButton>
+		</form>
+	);
+}

--- a/apps/site/src/app/portal/PortalDashboard.module.scss
+++ b/apps/site/src/app/portal/PortalDashboard.module.scss
@@ -318,6 +318,21 @@
 	text-align: center;
 }
 
+.declineForm {
+	display: flex;
+	justify-content: center;
+	width: min(100%, 30rem);
+	box-shadow: 0 4px 6px rgba(0, 0, 0, 0.28);
+}
+
+.declineButton {
+	width: 100%;
+	min-height: 4rem;
+	font-size: clamp(1rem, 3.5vw, 1.35rem) !important;
+	line-height: 1.3;
+	text-align: center;
+}
+
 @include utils.media-breakpoint-up(md) {
 	.container {
 		padding-top: 7.5rem;

--- a/apps/site/src/app/portal/PortalDashboard.tsx
+++ b/apps/site/src/app/portal/PortalDashboard.tsx
@@ -4,9 +4,14 @@ import RetroWindow from "@/components/RetroWindow/RetroWindow";
 import { ParticipantRole } from "@/lib/userRecord";
 import type { Identity } from "@/lib/utils/useUserIdentity";
 
-import { resolvePortalState, type PortalState } from "./portalState";
+import {
+	canDeclineAcceptance,
+	resolvePortalState,
+	type PortalState,
+} from "./portalState";
 import CheckInQrBox from "./CheckInQrBox";
 import CompletedTasksBox from "./CompletedTasksBox";
+import DeclineAcceptanceBox from "./DeclineAcceptanceBox";
 import PortalStatusBox from "./PortalStatusBox";
 import PortalTextBox from "./PortalTextBox";
 import RsvpBox from "./RsvpBox";
@@ -71,6 +76,7 @@ export default function PortalDashboard({ identity }: PortalDashboardProps) {
 							portalState={portalState}
 							identity={identity}
 						/>
+						{canDeclineAcceptance(identity) && <DeclineAcceptanceBox />}
 					</div>
 				</RetroWindow>
 			</div>

--- a/apps/site/src/app/portal/portalState.ts
+++ b/apps/site/src/app/portal/portalState.ts
@@ -1,4 +1,10 @@
-import { Decision, Status } from "@/lib/userRecord";
+import {
+	Decision,
+	ParticipantRole,
+	ProcessStatus,
+	ReviewStatus,
+	Status,
+} from "@/lib/userRecord";
 import type { Identity } from "@/lib/utils/useUserIdentity";
 
 export type PortalStatusTone =
@@ -117,4 +123,22 @@ export function resolvePortalState(identity: Identity): PortalState {
 	}
 
 	return portalStateByTone.submitted;
+}
+
+const declineableStatuses: ReadonlySet<string> = new Set([
+	Decision.Accepted,
+	ReviewStatus.Reviewed,
+	ProcessStatus.WaiverSigned,
+	ProcessStatus.Confirmed,
+]);
+
+export function canDeclineAcceptance(identity: Identity): boolean {
+	return (
+		identity.roles.includes(ParticipantRole.Applicant) &&
+		identity.roles.includes(ParticipantRole.Hacker) &&
+		!identity.roles.includes(ParticipantRole.Mentor) &&
+		identity.decision === Decision.Accepted &&
+		identity.status !== null &&
+		declineableStatuses.has(identity.status)
+	);
 }

--- a/apps/site/src/components/PrimaryButton/PrimaryButton.module.scss
+++ b/apps/site/src/components/PrimaryButton/PrimaryButton.module.scss
@@ -51,3 +51,9 @@
 	--button-background-hover: #e5a600;
 	--button-background-active: #bf8f00;
 }
+
+.red {
+	--button-background: #8d0000;
+	--button-background-hover: #a30000;
+	--button-background-active: #6b0000;
+}

--- a/apps/site/src/components/PrimaryButton/PrimaryButton.tsx
+++ b/apps/site/src/components/PrimaryButton/PrimaryButton.tsx
@@ -10,7 +10,7 @@ interface PrimaryButtonProps {
 	type?: "submit" | "reset" | "button" | undefined;
 	className?: string;
 	variant?: "small" | "large";
-	color?: "blue" | "green" | "yellow";
+	color?: "blue" | "green" | "yellow" | "red";
 	disabled?: boolean;
 	onClick?: MouseEventHandler<HTMLButtonElement>;
 	children: React.ReactNode;
@@ -34,6 +34,7 @@ const PrimaryButton = ({
 		blue: styles.blue,
 		green: styles.green,
 		yellow: styles.yellow,
+		red: styles.red,
 	};
 
 	if (!href) {


### PR DESCRIPTION
Closes #361 

Accepted hackers can now void their own application from the portal, matching irvinehacks-site's pattern of posting to the shared POST /api/user/decline-acceptance endpoint. The button is gated to Hackers whose decision/status make them eligible to self-decline (matching the backend's allowed_decline_statuses), and reuses PrimaryButton with a new red color variant.

- New `DeclineAcceptanceBox`: a native `<form method="post" action="/api/user/decline-acceptance">` guarded by `window.confirm()`, rendering a red `PrimaryButton` ("I am no longer able to attend ZotHacks 2026"). The `/api/*` rewrite + `X-Hackathon-Name: zothacks` middleware apply to the form POST, so it reaches the IrvineHacks backend with cookie auth.
- Gating via `canDeclineAcceptance(identity)`: button only shows for Hackers (not Mentors) with `decision === ACCEPTED` and a current status in `ACCEPTED` / `REVIEWED` / `WAIVER_SIGNED` / `CONFIRMED`, mirroring the backend's `allowed_decline_statuses`. Checked-in (`ATTENDING`) users are excluded.
- New `red` color variant on `PrimaryButton` (`#8d0000`, matching the portal's rejected-status tone), plus `.declineForm` / `.declineButton` styles in the portal dashboard following the existing `.rsvpButton` pattern.

<img width="988" height="1990" alt="image" src="https://github.com/user-attachments/assets/77e36cc2-0a99-4936-ac5e-894d78ffa9d0" />
<img width="988" height="1295" alt="image" src="https://github.com/user-attachments/assets/9189cd17-2f74-4643-b01b-381bceaa203b" />
